### PR TITLE
Fix edge cases in message loading and network I/O

### DIFF
--- a/src/message.c
+++ b/src/message.c
@@ -61,7 +61,7 @@ int message_load(message_t **messages, int max_messages) {
     }
 
     long file_size = ftell(fp);
-    if (file_size == 0) {
+    if (file_size <= 0) {
         fclose(fp);
         *messages = msg_array;
         return 0;

--- a/src/ssh_server.c
+++ b/src/ssh_server.c
@@ -194,8 +194,10 @@ static ip_rate_limit_t* get_rate_limit_entry(const char *ip) {
                 oldest_idx = i;
             }
         }
-        fprintf(stderr, "Warning: rate-limit table full, evicting active IP %s\n",
-                g_rate_limits[oldest_idx].ip);
+        fprintf(stderr, "Warning: rate-limit table full, evicting active IP %s "
+                "(%d active connections lost)\n",
+                g_rate_limits[oldest_idx].ip,
+                g_rate_limits[oldest_idx].active_connections);
     }
 
     /* Reset and reuse */
@@ -487,7 +489,9 @@ int client_send(client_t *client, const char *data, size_t len) {
     }
 
     while (total < len) {
-        int sent = ssh_channel_write(client->channel, data + total, len - total);
+        size_t remaining = len - total;
+        uint32_t chunk = (remaining > 32768) ? 32768 : (uint32_t)remaining;
+        int sent = ssh_channel_write(client->channel, data + total, chunk);
         if (sent <= 0) {
             pthread_mutex_unlock(&client->io_lock);
             return -1;


### PR DESCRIPTION
## Summary

Closes #19

- Guard `ftell()` return in `message_load()`: treat `-1` (error) the same as `0` (empty file) to prevent corrupted backward scan
- Cap `ssh_channel_write` chunks to 32KB in `client_send()` to prevent `size_t`-to-`uint32_t` narrowing on large buffers
- Include evicted connection count in rate-limit table overflow warning for better diagnostics

## Test plan

- [ ] Build with `make` — no new warnings
- [ ] Run `make test` — existing tests pass
- [ ] Verify message loading still works correctly with existing log files
- [ ] Verify chat messages still send correctly (no regression from chunked writes)