### PR TITLE
fix: correct pubkey auth, strncpy warning, and NUL byte validation

### DIFF
--- a/src/ssh_server.c
+++ b/src/ssh_server.c
@@ -1109,9 +1109,8 @@ static void execute_command(client_t *client) {
                     (max_hist - 1) * sizeof(client->command_history[0]));
             client->command_history_count = max_hist - 1;
         }
-        strncpy(client->command_history[client->command_history_count],
-                cmd, sizeof(client->command_history[0]) - 1);
-        client->command_history[client->command_history_count][sizeof(client->command_history[0]) - 1] = '\0';
+        snprintf(client->command_history[client->command_history_count],
+                 sizeof(client->command_history[0]), "%s", cmd);
         client->command_history_count++;
         client->command_history_pos = client->command_history_count;
     }
@@ -1740,10 +1739,11 @@ static int auth_pubkey(ssh_session session, const char *user,
         return SSH_AUTH_DENIED;
     }
 
-    /* Only accept after the signature has been verified by libssh.
-     * SSH_PUBLICKEY_STATE_NONE is just a key offer — no proof of possession. */
+    /* SSH_PUBLICKEY_STATE_NONE = key offer (no signature yet).
+     * Return SUCCESS to tell libssh "I accept this key, verify the signature."
+     * SSH_PUBLICKEY_STATE_VALID = signature verified by libssh. */
     if (signature_state != SSH_PUBLICKEY_STATE_VALID) {
-        return SSH_AUTH_PARTIAL;
+        return SSH_AUTH_SUCCESS;
     }
 
     ctx->auth_success = true;

--- a/src/utf8.c
+++ b/src/utf8.c
@@ -193,9 +193,9 @@ bool utf8_is_valid_sequence(const char *bytes, int len) {
     uint32_t codepoint = 0;
     switch (len) {
         case 1:
-            /* 0xxxxxxx - valid range: 0x00-0x7F */
+            /* 0xxxxxxx - valid range: 0x01-0x7F (reject NUL) */
             codepoint = b[0];
-            if (codepoint > 0x7F) return false;
+            if (codepoint == 0 || codepoint > 0x7F) return false;
             break;
         case 2:
             /* 110xxxxx 10xxxxxx - valid range: 0x80-0x7FF */


### PR DESCRIPTION
## Summary
- **auth_pubkey**: Return `SSH_AUTH_SUCCESS` instead of `SSH_AUTH_PARTIAL` for key offers (`SSH_PUBLICKEY_STATE_NONE`). `SSH_AUTH_PARTIAL` incorrectly signals partial authentication, confusing SSH clients into thinking they need additional auth methods after a simple key probe.
- **command history**: Replace `strncpy` with `snprintf` to eliminate `-Wstringop-truncation` warning on GCC (src and dst are both 255 bytes).
- **UTF-8 validation**: Reject NUL byte (0x00) in `utf8_is_valid_sequence` to prevent C string truncation when embedded NUL bytes appear in user input.

Closes #34

## Test plan
- [x] Clean build on macOS (no warnings except pre-existing ssh_pki_generate deprecation)
- [x] Clean build on Linux/ali (zero warnings, strncpy warning eliminated)
- [x] Clean build on Linux/oss (zero warnings)
- [x] Verified ali server responds to `health`, `stats` exec commands
- [x] Verified oss server responds to `health` exec command
- [x] Both servers deployed and running with these fixes