### PR TITLE
fix: deadlock, use-after-free, log rotation, and tail parsing

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -22,6 +22,7 @@
 #define MAX_EXEC_COMMAND_LEN 1024
 #define MAX_CLIENTS 64
 #define LOG_FILE "messages.log"
+#define MAX_LOG_SIZE (10 * 1024 * 1024)  /* 10 MiB */
 #define HOST_KEY_FILE "host_key"
 #define TNT_DEFAULT_STATE_DIR "."
 

--- a/src/message.c
+++ b/src/message.c
@@ -227,7 +227,16 @@ int message_save(const message_t *msg) {
         rc = -1;
     }
 
+    /* Rotate if the log exceeds MAX_LOG_SIZE */
+    long file_size = ftell(fp);
     fclose(fp);
+
+    if (file_size > MAX_LOG_SIZE) {
+        char backup_path[PATH_MAX + 4];
+        snprintf(backup_path, sizeof(backup_path), "%s.1", log_path);
+        rename(log_path, backup_path);
+    }
+
     pthread_mutex_unlock(&g_message_file_lock);
     return rc;
 }

--- a/src/ssh_server.c
+++ b/src/ssh_server.c
@@ -895,7 +895,7 @@ static int parse_tail_count(const char *args, int *count) {
         return 0;
     }
 
-    if (strncmp(args, "-n", 2) == 0 && isspace((unsigned char)args[2])) {
+    if (strncmp(args, "-n", 2) == 0) {
         args += 2;
         while (*args && isspace((unsigned char)*args)) {
             args++;
@@ -1171,20 +1171,27 @@ static void execute_command(client_t *client) {
                            "       w <username> <message>\n");
         } else {
             bool found = false;
+            client_t *target = NULL;
             pthread_rwlock_rdlock(&g_room->lock);
             for (int i = 0; i < g_room->client_count; i++) {
                 if (strcmp(g_room->clients[i]->username, target_name) == 0) {
-                    char whisper[MAX_MESSAGE_LEN];
-                    snprintf(whisper, sizeof(whisper),
-                             "\r\n\033[35m[whisper from %s]: %s\033[0m\r\n",
-                             client->username, rest);
-                    client_send(g_room->clients[i], whisper, strlen(whisper));
-                    g_room->clients[i]->redraw_pending = true;
+                    target = g_room->clients[i];
+                    client_addref(target);
                     found = true;
                     break;
                 }
             }
             pthread_rwlock_unlock(&g_room->lock);
+
+            if (target) {
+                char whisper[MAX_MESSAGE_LEN];
+                snprintf(whisper, sizeof(whisper),
+                         "\r\n\033[35m[whisper from %s]: %s\033[0m\r\n",
+                         client->username, rest);
+                client_send(target, whisper, strlen(whisper));
+                target->redraw_pending = true;
+                client_release(target);
+            }
 
             if (found) {
                 buffer_appendf(output, sizeof(output), &pos,
@@ -1648,6 +1655,12 @@ cleanup:
     }
 
     release_ip_connection(client->client_ip);
+
+    /* Remove channel callbacks before releasing refs to prevent use-after-free
+     * if a callback fires between the two releases. */
+    if (client->channel && client->channel_cb) {
+        ssh_remove_channel_callbacks(client->channel, client->channel_cb);
+    }
 
     /* Release the callback reference (paired with addref before install_client_channel_callbacks) */
     client_release(client);


### PR DESCRIPTION
## Summary
- **Whisper deadlock**: `client_send` was called while holding `g_room->lock`, creating a lock-ordering inversion with `tui_render_screen`. Fixed by copying the target client pointer with `client_addref`, releasing the lock, then sending.
- **Use-after-free**: Channel callbacks could fire on freed memory because `ssh_remove_channel_callbacks` was called inside `client_release` after the struct was being freed. Fixed by removing callbacks before releasing refs.
- **Log rotation**: Added 10 MiB log size limit with single-file rotation (`messages.log` → `messages.log.1`) to prevent unbounded growth on public servers.
- **tail parsing**: `tail -n5` now works in addition to `tail -n 5`, matching standard Unix behavior.

Closes #36

## Test plan
- [x] Clean build on macOS
- [ ] CI build on Linux
- [ ] Manual test: whisper between two clients simultaneously
- [ ] Manual test: `ssh host -p 2222 tail -n5` returns last 5 messages