### PR TITLE
feat: add --port, --version long options and improved help

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -31,7 +31,8 @@ int main(int argc, char **argv) {
 
     /* Parse command line arguments */
     for (int i = 1; i < argc; i++) {
-        if (strcmp(argv[i], "-p") == 0 && i + 1 < argc) {
+        if ((strcmp(argv[i], "-p") == 0 || strcmp(argv[i], "--port") == 0) &&
+            i + 1 < argc) {
             char *end;
             long val = strtol(argv[i + 1], &end, 10);
             if (*end != '\0' || val <= 0 || val > 65535) {
@@ -47,13 +48,23 @@ int main(int argc, char **argv) {
                 return 1;
             }
             i++;
+        } else if (strcmp(argv[i], "-V") == 0 || strcmp(argv[i], "--version") == 0) {
+            printf("tnt %s\n", TNT_VERSION);
+            return 0;
         } else if (strcmp(argv[i], "-h") == 0 || strcmp(argv[i], "--help") == 0) {
-            printf("TNT - Terminal Network Talk\n");
-            printf("Usage: %s [options]\n", argv[0]);
+            printf("tnt %s - anonymous SSH chat server\n\n", TNT_VERSION);
+            printf("Usage: %s [options]\n\n", argv[0]);
             printf("Options:\n");
-            printf("  -p PORT    Listen on PORT (default: %d)\n", DEFAULT_PORT);
-            printf("  -d DIR     Store host key and logs in DIR\n");
-            printf("  -h         Show this help\n");
+            printf("  -p, --port PORT       Listen on PORT (default: %d)\n", DEFAULT_PORT);
+            printf("  -d, --state-dir DIR   Store host key and logs in DIR\n");
+            printf("  -V, --version         Show version\n");
+            printf("  -h, --help            Show this help\n");
+            printf("\nEnvironment:\n");
+            printf("  PORT                  Default listening port\n");
+            printf("  TNT_STATE_DIR         State directory\n");
+            printf("  TNT_ACCESS_TOKEN      Require this password for SSH auth\n");
+            printf("  TNT_MAX_CONNECTIONS   Global connection limit (default: 64)\n");
+            printf("  TNT_RATE_LIMIT        Set to 0 to disable rate limiting\n");
             return 0;
         } else {
             fprintf(stderr, "Unknown option: %s\n", argv[i]);

--- a/tnt.1
+++ b/tnt.1
@@ -4,11 +4,12 @@
 tnt \- anonymous SSH chat server with Vim\-style TUI
 .SH SYNOPSIS
 .B tnt
-.RB [ \-p
+.RB [ \-p | \-\-port
 .IR port ]
-.RB [ \-d
+.RB [ \-d | \-\-state\-dir
 .IR dir ]
-.RB [ \-h ]
+.RB [ \-V | \-\-version ]
+.RB [ \-h | \-\-help ]
 .SH DESCRIPTION
 .B tnt
 is a multi\-user anonymous chat server accessed over SSH.
@@ -21,7 +22,7 @@ The server supports CJK and emoji input, rate limiting, access tokens, and
 a non\-interactive exec interface for scripting.
 .SH OPTIONS
 .TP
-.BI \-p " port"
+.BR \-p ", " \-\-port " " \fIport\fR
 Listen on
 .I port
 instead of the default 2222.
@@ -29,7 +30,7 @@ Overrides the
 .B PORT
 environment variable.
 .TP
-.BI \-d " dir"
+.BR \-d ", " \-\-state\-dir " " \fIdir\fR
 Store the host key and message log in
 .IR dir .
 Overrides the
@@ -37,7 +38,10 @@ Overrides the
 environment variable.
 Defaults to the current working directory.
 .TP
-.B \-h
+.BR \-V ", " \-\-version
+Print version and exit.
+.TP
+.BR \-h ", " \-\-help
 Print a short usage summary and exit.
 .SH CONNECTING
 .PP


### PR DESCRIPTION
## Summary
- Add `--port` as long-form alias for `-p`
- Add `-V` / `--version` flag that prints `tnt <version>`
- Improve `--help` output with environment variable documentation
- Update manpage with long option forms and `--version` entry

Aligns with Roadmap Stage 1 goal of consistent long options.

## Test plan
- [x] `tnt --version` prints `tnt 1.0.0`
- [x] `tnt --help` shows all options and environment variables
- [x] `tnt --port 3000` works same as `-p 3000`
- [ ] CI passes