### PR TITLE
ci: harden exec-mode test against macOS connection races

### DIFF
--- a/tests/test_exec_mode.sh
+++ b/tests/test_exec_mode.sh
@@ -25,12 +25,20 @@ if [ ! -f "$BIN" ]; then
     exit 1
 fi
 
-SSH_OPTS="-n -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes -p $PORT"
+# ConnectionAttempts/ConnectTimeout make each exec connection resilient to the
+# transient "connection closed during identification" races seen on slow CI
+# runners (notably macOS).
+SSH_OPTS="-n -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes -o ConnectionAttempts=3 -o ConnectTimeout=15 -p $PORT"
 TNTCTL_OPTS="--host-key-checking no --known-hosts /dev/null"
 
 echo "=== TNT Exec Mode Tests ==="
 
-TNT_LANG=zh TNT_RATE_LIMIT=0 $BIN -p "$PORT" -d "$STATE_DIR" >"${STATE_DIR}/server.log" 2>&1 &
+# This suite opens many short-lived exec connections in quick succession. On
+# macOS the closed sockets linger, so the default per-IP concurrency cap (5)
+# can be transiently exceeded and a connection refused mid-suite. Raise the
+# caps well above the number of in-flight connections this test can produce.
+TNT_LANG=zh TNT_RATE_LIMIT=0 TNT_MAX_CONN_PER_IP=256 TNT_MAX_CONNECTIONS=256 \
+    $BIN -p "$PORT" -d "$STATE_DIR" >"${STATE_DIR}/server.log" 2>&1 &
 SERVER_PID=$!
 
 HEALTH_OUTPUT=""


### PR DESCRIPTION
## Problem
`test_exec_mode.sh` intermittently fails **only on the macOS CI runner** with `✗ users usage output unexpected` (observed on PR #62). The same test passes on Ubuntu CI and locally on macOS.

## Root cause
The suite opens many short-lived SSH exec connections in quick succession. On macOS the closed sockets linger (TIME_WAIT), so the server's default **per-IP concurrency cap (`TNT_DEFAULT_MAX_CONN_PER_IP = 5`)** is transiently exceeded and a connection is refused mid-suite → empty output → the usage `grep` fails. The test disabled the *rate* limit (`TNT_RATE_LIMIT=0`) but not the *concurrency* cap.

## Fix
- Launch the test server with high caps: `TNT_MAX_CONN_PER_IP=256 TNT_MAX_CONNECTIONS=256` (well above the in-flight count this suite produces).
- Add `-o ConnectionAttempts=3 -o ConnectTimeout=15` to the test's `SSH_OPTS` so a dropped identification handshake is retried rather than failing the assertion.

No product code changes; test-only. Verified stable across repeated local macOS runs (25/25 each).