### PR TITLE
release: TNT 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A minimalist terminal chat server with Vim-style interface over SSH.
 
 **Pinned release installer:**
 ```sh
-curl -sSL https://raw.githubusercontent.com/m1ngsama/TNT/v1.1.0/install.sh | VERSION=v1.1.0 sh
+curl -sSL https://raw.githubusercontent.com/m1ngsama/TNT/v1.2.0/install.sh | VERSION=v1.2.0 sh
 ```
 The installer verifies downloaded release binaries against `checksums.txt`
 before installing them. Older releases may provide only `tnt`; newer releases

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+## 1.2.0 - 2026-06-29
+
+### Added
+- Per-session `:theme` colour command (`:theme`, alias `:color`) with seven
+  portable 16-colour accent themes: cyan (default), green, magenta, blue,
+  amber, red, and mono. Themes are per-session personalization and never
+  affect other users or server state.
+- COMMAND-mode Tab completion: completes command names (filling the longest
+  common prefix and listing candidates inline when ambiguous) and the first
+  argument for `:theme`/`:lang` values and online usernames for `:msg`/`:w`.
+- Newcomer onboarding: a dim "getting started" line on the welcome screen and
+  a richer always-visible INSERT hint that points to `:` commands and `:help`.
+- `packaging/completions/` shell completion for `tntctl` (bash, zsh, fish).
+
 ### Changed
 - `dump` now defaults to the last 100 persisted records; use `dump -n N` for an
   explicit bounded export or `dump --all` for a full persisted-log export.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -4,7 +4,7 @@
 
 Pinned release install:
 ```bash
-curl -sSL https://raw.githubusercontent.com/m1ngsama/TNT/v1.1.0/install.sh | VERSION=v1.1.0 sh
+curl -sSL https://raw.githubusercontent.com/m1ngsama/TNT/v1.2.0/install.sh | VERSION=v1.2.0 sh
 ```
 
 Moving latest-release installer, convenient for test deployments:
@@ -200,7 +200,7 @@ sudo firewall-cmd --reload
 sudo systemctl stop tnt
 
 # Re-run the pinned installer for the version you want
-curl -sSL https://raw.githubusercontent.com/m1ngsama/TNT/v1.1.0/install.sh | VERSION=v1.1.0 sh
+curl -sSL https://raw.githubusercontent.com/m1ngsama/TNT/v1.2.0/install.sh | VERSION=v1.2.0 sh
 
 # Start service
 sudo systemctl start tnt

--- a/include/common.h
+++ b/include/common.h
@@ -14,7 +14,7 @@
 #include "config_defaults.h"
 
 /* Project Metadata */
-#define TNT_VERSION "1.1.0"
+#define TNT_VERSION "1.2.0"
 
 /* Public process/exec exit statuses.  TNT follows the common sysexits(3)
  * convention for usage errors while keeping runtime failures portable. */

--- a/packaging/arch/.SRCINFO
+++ b/packaging/arch/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = tnt-chat
 	pkgdesc = SSH-native terminal chat server with a Vim-style interface
-	pkgver = 1.1.0
+	pkgver = 1.2.0
 	pkgrel = 1
 	url = https://github.com/m1ngsama/TNT
 	arch = x86_64
@@ -9,7 +9,7 @@ pkgbase = tnt-chat
 	makedepends = gcc
 	makedepends = make
 	depends = libssh
-	source = tnt-chat-v1.1.0-source.tar.gz::https://github.com/m1ngsama/TNT/releases/download/v1.1.0/tnt-chat-v1.1.0-source.tar.gz
+	source = tnt-chat-v1.2.0-source.tar.gz::https://github.com/m1ngsama/TNT/releases/download/v1.2.0/tnt-chat-v1.2.0-source.tar.gz
 	source = tnt-chat.sysusers
 	sha256sums = SKIP
 	sha256sums = 8a1f7dfbdc9f1305c4ed50d80e89f91333ffdf937890c497f93e41abaf76e3ed

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: M1ng <contact@m1ng.space>
 
 pkgname=tnt-chat
-pkgver=1.1.0
+pkgver=1.2.0
 pkgrel=1
 pkgdesc='SSH-native terminal chat server with a Vim-style interface'
 arch=('x86_64' 'aarch64')

--- a/packaging/debian/debian/changelog
+++ b/packaging/debian/debian/changelog
@@ -1,3 +1,11 @@
+tnt-chat (1.2.0-1) unstable; urgency=medium
+
+  * Add per-session :theme colour command.
+  * Add COMMAND-mode Tab completion and newcomer onboarding guidance.
+  * Add tntctl shell completion scripts.
+
+ -- M1ng <contact@m1ng.space>  Mon, 29 Jun 2026 00:00:00 +0800
+
 tnt-chat (1.1.0-1) unstable; urgency=medium
 
   * Initial package draft.

--- a/packaging/homebrew/tnt-chat.rb
+++ b/packaging/homebrew/tnt-chat.rb
@@ -1,7 +1,7 @@
 class TntChat < Formula
   desc "SSH-native terminal chat server with a Vim-style interface"
   homepage "https://github.com/m1ngsama/TNT"
-  url "https://github.com/m1ngsama/TNT/releases/download/v1.1.0/tnt-chat-v1.1.0-source.tar.gz"
+  url "https://github.com/m1ngsama/TNT/releases/download/v1.2.0/tnt-chat-v1.2.0-source.tar.gz"
   sha256 "REPLACE_WITH_RELEASE_TARBALL_SHA256"
   license "MIT"
 

--- a/tnt.1
+++ b/tnt.1
@@ -1,5 +1,5 @@
 .\" tnt(1) - Terminal Network Talk
-.TH TNT 1 "2026-06-16" "TNT 1.1.0" "User Commands"
+.TH TNT 1 "2026-06-29" "TNT 1.2.0" "User Commands"
 .SH NAME
 tnt \- anonymous SSH chat server with Vim\-style TUI
 .SH SYNOPSIS

--- a/tntctl.1
+++ b/tntctl.1
@@ -1,5 +1,5 @@
 .\" tntctl(1) - TNT control client
-.TH TNTCTL 1 "2026-06-16" "TNT 1.1.0" "User Commands"
+.TH TNTCTL 1 "2026-06-29" "TNT 1.2.0" "User Commands"
 .SH NAME
 tntctl \- thin control client for a TNT server
 .SH SYNOPSIS


### PR DESCRIPTION
## Summary
Cuts **TNT 1.2.0**, bundling this cycle's user-facing work and the previously-unreleased hardening already on `main`.

### Highlights (since 1.1.0)
- **Per-session `:theme` colour command** (7 themes; alias `:color`).
- **COMMAND-mode Tab completion** — command names + inline candidates, and first-arg completion for `:theme`/`:lang`/`:msg`.
- **Newcomer onboarding** — welcome-screen guide line + richer INSERT hint.
- **`tntctl` shell completion** (bash/zsh/fish) under `packaging/completions/`.
- Plus the already-merged `dump`/persistence changes and module/systemd hardening.

### Release metadata (all aligned; `scripts/release_check.sh` passes locally, exit 0)
- `include/common.h` `TNT_VERSION` → 1.2.0
- `tnt.1`, `tntctl.1` `.TH` → TNT 1.2.0 (2026-06-29)
- Arch `PKGBUILD`/`.SRCINFO`, Homebrew formula, Debian `changelog` → 1.2.0
- `README.md` / `docs/DEPLOYMENT.md` installer pins → v1.2.0
- `docs/CHANGELOG.md` → `## 1.2.0 - 2026-06-29`

After merge, tagging `v1.2.0` on `main` triggers the release workflow (linux amd64/arm64 + macOS builds, checksums, GitHub Release).