### PR TITLE
ci: harden remaining integration tests against connection races

### DIFF
--- a/docs/MODULE_PROTOCOL.md
+++ b/docs/MODULE_PROTOCOL.md
@@ -89,7 +89,7 @@ Optional compatibility fields:
 TNT starts a module process and writes a handshake event:
 
 ```json
-{"type":"handshake","protocol":"tnt.module.v1","server":{"name":"tnt","version":"1.1.0"}}
+{"type":"handshake","protocol":"tnt.module.v1","server":{"name":"tnt","version":"1.2.0"}}
 ```
 
 The module should answer:

--- a/tests/test_anonymous_access.sh
+++ b/tests/test_anonymous_access.sh
@@ -23,7 +23,7 @@ if [ ! -f "$BIN" ]; then
     exit 1
 fi
 
-SSH_BASE="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o PubkeyAuthentication=no -p $PORT"
+SSH_BASE="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o PubkeyAuthentication=no -o ConnectionAttempts=3 -o ConnectTimeout=15 -p $PORT"
 
 wait_for_health() {
     local out
@@ -76,7 +76,7 @@ EOF
 
 echo "=== TNT Anonymous Access Tests ==="
 
-TNT_LANG=zh TNT_RATE_LIMIT=0 "$BIN" -p "$PORT" -d "$STATE_DIR" \
+TNT_LANG=zh TNT_RATE_LIMIT=0 TNT_MAX_CONN_PER_IP=256 TNT_MAX_CONNECTIONS=256 "$BIN" -p "$PORT" -d "$STATE_DIR" \
     >"$STATE_DIR/server.log" 2>&1 &
 SERVER_PID=$!
 

--- a/tests/test_basic.sh
+++ b/tests/test_basic.sh
@@ -8,7 +8,7 @@ FAIL=0
 BIN="../tnt"
 SERVER_PID=""
 STATE_DIR=$(mktemp -d "${TMPDIR:-/tmp}/tnt-basic-test.XXXXXX")
-SSH_HEALTH_OPTS="-n -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes -p $PORT"
+SSH_HEALTH_OPTS="-n -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes -o ConnectionAttempts=3 -o ConnectTimeout=15 -p $PORT"
 
 cleanup() {
     if [ -n "$SERVER_PID" ]; then
@@ -45,8 +45,10 @@ if ! command -v expect >/dev/null 2>&1; then
     exit 0
 fi
 
-# Start server
-"$BIN" -p "$PORT" -d "$STATE_DIR" >"$STATE_DIR/server.log" 2>&1 &
+# Start server. High per-IP/global caps so the suite's rapid SSH connections
+# do not transiently exceed the default per-IP limit on slow CI runners.
+TNT_MAX_CONN_PER_IP=256 TNT_MAX_CONNECTIONS=256 \
+    "$BIN" -p "$PORT" -d "$STATE_DIR" >"$STATE_DIR/server.log" 2>&1 &
 SERVER_PID=$!
 
 # Test 1: Server started and accepts exec health checks

--- a/tests/test_empty_view.sh
+++ b/tests/test_empty_view.sh
@@ -28,11 +28,11 @@ if [ ! -f "$BIN" ]; then
     exit 1
 fi
 
-SSH_OPTS="-e none -tt -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -p $PORT"
+SSH_OPTS="-e none -tt -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -o ConnectionAttempts=3 -o ConnectTimeout=15 -p $PORT"
 
 echo "=== TNT Empty View Test ==="
 
-TNT_LANG=en TNT_RATE_LIMIT=0 "$BIN" --bind 127.0.0.1 \
+TNT_LANG=en TNT_RATE_LIMIT=0 TNT_MAX_CONN_PER_IP=256 TNT_MAX_CONNECTIONS=256 "$BIN" --bind 127.0.0.1 \
     -p "$PORT" -d "$STATE_DIR" >"$STATE_DIR/server.log" 2>&1 &
 SERVER_PID=$!
 

--- a/tests/test_interactive_input.sh
+++ b/tests/test_interactive_input.sh
@@ -28,11 +28,11 @@ if [ ! -f "$BIN" ]; then
     exit 1
 fi
 
-SSH_OPTS="-e none -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -p $PORT"
+SSH_OPTS="-e none -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -o ConnectionAttempts=3 -o ConnectTimeout=15 -p $PORT"
 
 echo "=== TNT Interactive Input Tests ==="
 
-TNT_LANG=zh TNT_RATE_LIMIT=0 "$BIN" -p "$PORT" -d "$STATE_DIR" >"$STATE_DIR/server.log" 2>&1 &
+TNT_LANG=zh TNT_RATE_LIMIT=0 TNT_MAX_CONN_PER_IP=256 TNT_MAX_CONNECTIONS=256 "$BIN" -p "$PORT" -d "$STATE_DIR" >"$STATE_DIR/server.log" 2>&1 &
 SERVER_PID=$!
 
 SERVER_READY=0

--- a/tests/test_module_runtime.sh
+++ b/tests/test_module_runtime.sh
@@ -31,7 +31,7 @@ if [ ! -f "$BIN" ]; then
     exit 1
 fi
 
-SSH_OPTS="-n -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes -p $PORT"
+SSH_OPTS="-n -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes -o ConnectionAttempts=3 -o ConnectTimeout=15 -p $PORT"
 
 mkdir -p "$MODULE_DIR"
 cat >"$MODULE_DIR/tnt-module.json" <<'JSON'
@@ -142,7 +142,7 @@ chmod +x "$INVALID_MODULE_DIR/invalid-module.sh"
 echo "=== TNT Module Runtime Tests ==="
 
 TNT_LANG=en TNT_RATE_LIMIT=0 TNT_MODULE_PATHS="$MODULE_DIR" \
-    "$BIN" -p "$PORT" -d "$STATE_DIR" >"$STATE_DIR/server.log" 2>&1 &
+    TNT_MAX_CONN_PER_IP=256 TNT_MAX_CONNECTIONS=256 "$BIN" -p "$PORT" -d "$STATE_DIR" >"$STATE_DIR/server.log" 2>&1 &
 SERVER_PID=$!
 
 HEALTH_OUTPUT=""
@@ -198,7 +198,7 @@ fi
 stop_server
 
 TNT_LANG=en TNT_RATE_LIMIT=0 TNT_MODULE_PATHS="$FLOOD_MODULE_DIR" \
-    "$BIN" -p "$PORT" -d "$STATE_DIR" >"$STATE_DIR/flood-server.log" 2>&1 &
+    TNT_MAX_CONN_PER_IP=256 TNT_MAX_CONNECTIONS=256 "$BIN" -p "$PORT" -d "$STATE_DIR" >"$STATE_DIR/flood-server.log" 2>&1 &
 SERVER_PID=$!
 
 HEALTH_OUTPUT=""
@@ -268,7 +268,7 @@ fi
 stop_server
 
 TNT_LANG=en TNT_RATE_LIMIT=0 TNT_MODULE_PATHS="$INVALID_MODULE_DIR" \
-    "$BIN" -p "$PORT" -d "$STATE_DIR" >"$STATE_DIR/invalid-server.log" 2>&1 &
+    TNT_MAX_CONN_PER_IP=256 TNT_MAX_CONNECTIONS=256 "$BIN" -p "$PORT" -d "$STATE_DIR" >"$STATE_DIR/invalid-server.log" 2>&1 &
 SERVER_PID=$!
 
 HEALTH_OUTPUT=""

--- a/tests/test_mute_joins_view.sh
+++ b/tests/test_mute_joins_view.sh
@@ -28,7 +28,7 @@ if [ ! -f "$BIN" ]; then
     exit 1
 fi
 
-SSH_OPTS="-e none -tt -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -p $PORT"
+SSH_OPTS="-e none -tt -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -o ConnectionAttempts=3 -o ConnectTimeout=15 -p $PORT"
 
 echo "=== TNT Mute Joins View Test ==="
 
@@ -45,7 +45,7 @@ while [ "$i" -le 20 ]; do
     i=$((i + 1))
 done
 
-TNT_LANG=en TNT_RATE_LIMIT=0 "$BIN" --bind 127.0.0.1 \
+TNT_LANG=en TNT_RATE_LIMIT=0 TNT_MAX_CONN_PER_IP=256 TNT_MAX_CONNECTIONS=256 "$BIN" --bind 127.0.0.1 \
     -p "$PORT" -d "$STATE_DIR" >"$STATE_DIR/server.log" 2>&1 &
 SERVER_PID=$!
 


### PR DESCRIPTION
## Problem
Follow-up to #63. The integration suite intermittently goes red on loaded/macOS CI runners (seen on PR #62 and PR #64) because tests open many short-lived SSH connections in quick succession and transiently exceed the server's default per-IP concurrency cap (`TNT_DEFAULT_MAX_CONN_PER_IP = 5`). #63 fixed only `test_exec_mode.sh`; the same race affects the rest.

## Fix
Apply the #63 hardening to the other integration tests that launch a server and connect over SSH:
- `test_basic.sh`, `test_module_runtime.sh`, `test_anonymous_access.sh`, `test_interactive_input.sh`, `test_mute_joins_view.sh`, `test_empty_view.sh`

Each now:
- launches the test server with `TNT_MAX_CONN_PER_IP=256 TNT_MAX_CONNECTIONS=256` (root cause), and
- passes `-o ConnectionAttempts=3 -o ConnectTimeout=15` to its ssh options (SSH-layer resilience).

### Intentionally unchanged
- `test_user_lifecycle.sh` — already sets `--max-conn-per-ip 32`.
- `test_tntctl_cli.sh` — uses a fake ssh in PATH (no real server).
- `test_connection_limits.sh` — deliberately exercises the caps.

Also bumps the version in the `docs/MODULE_PROTOCOL.md` handshake example to 1.2.0.

## Verification
No product code touched. `make integration-test` and `make anonymous-access-test` pass locally (exit 0). This should eliminate the recurring re-run-to-green need.